### PR TITLE
Allow show/hiding options on condition

### DIFF
--- a/src/Blocks/Options/Option.php
+++ b/src/Blocks/Options/Option.php
@@ -6,9 +6,18 @@ abstract class Option
 {
     public array $attributes = [];
 
+    public string $wrapper = '_INJECT_';
+
     public static function make(...$args)
     {
         return new static(...$args);
+    }
+
+    public function condition($condition)
+    {
+        $this->wrapper = '<div x-show="'.($condition).'">_INJECT_</div>';
+
+        return $this;
     }
 
     public function render()
@@ -29,6 +38,6 @@ abstract class Option
 
     public function __toString()
     {
-        return $this->render();
+        return str_replace('_INJECT_', $this->render(), $this->wrapper);
     }
 }


### PR DESCRIPTION
Allows you to show an option if a condition is met. 

```php
Select::make(__('Image alignment'), 'image_alignment', [
    'left' => __('Left'),
    'right' => __('Right'),
    'center' => __('Center'),
])->condition('image'),
```

How it works: simply passes the string you fill in onto a wrapper div with the `x-show` attribute.