### PR TITLE
Truncate and tooltip

### DIFF
--- a/resources/css/paver.css
+++ b/resources/css/paver.css
@@ -138,6 +138,7 @@
             flex-direction: column;
             justify-content: center;
             align-items: center;
+            text-align: center;
             gap: 10px;
             color: var(--paver-color-dark);
 

--- a/resources/views/editor/sidebar.php
+++ b/resources/views/editor/sidebar.php
@@ -12,9 +12,15 @@
                 </div>
                 <div x-ref="blocksInserter" class="paver__block-grid paver__sortable">
                     <?php foreach(paver()->blocks() as $block) : ?>
-                        <div class="paver__sortable-item paver__block-handle" data-block="<?php echo $block['reference']; ?>">
+                        <div  x-paver-tooltip="text('<?php echo addslashes($block['name']); ?>')" class="paver__sortable-item paver__block-handle" data-block="<?php echo $block['reference']; ?>">
                             <span><?php echo $block['icon']; ?></span>
-                            <span><?php echo $block['name']; ?></span>
+                            <span><?php
+                                // Trucate the block name if it's too long
+                                if(strlen($block['name']) > 10) {
+                                    echo substr($block['name'], 0, 10) . '...';
+                                } else
+                                    echo $block['name'];
+                                ?></span>
                         </div>
                     <?php endforeach; ?>
                 </div>


### PR DESCRIPTION
This pull request includes several changes aimed at improving the user interface and enhancing the readability of block names in the editor sidebar.

### User Interface Improvements:

* [`resources/css/paver.css`](diffhunk://#diff-216d89970e3c9e8d7fdcff9e49f8289fee5588b32b7ae6a4ca01469003cc88eaR141): Added `text-align: center;` to ensure that text within the flex container is centered.

### Enhancements to Block Name Readability:

* [`resources/views/editor/sidebar.php`](diffhunk://#diff-243d677229dd29390003f680ea84eccc181b361ab2cd56481dc4b0d7acf34813L15-R23): Added a tooltip to display the full block name on hover and implemented logic to truncate the block name if it exceeds 10 characters.