### PR TITLE
Auto-load scripts and styles declared by block options

### DIFF
--- a/docs/beta/block-options.md
+++ b/docs/beta/block-options.md
@@ -36,7 +36,7 @@ class Example extends Block
 
 ## Available options
 
-Though you're  free to write your options yourself, some pre made options have been made available for you.
+Though you're  free to write your options yourself, some pre made options have been made available for you. You can also create [custom options](/docs/{{version}}/custom-options).
 
 ### Input
 

--- a/docs/beta/custom-options.md
+++ b/docs/beta/custom-options.md
@@ -1,0 +1,159 @@
+# Custom options
+
+- [Basic example](#basic-example)
+- [How binding works](#how-binding-works)
+- [Loading scripts and styles](#loading-scripts-and-styles)
+- [Full example: a Summernote rich text option](#full-example-a-summernote-rich-text-option)
+- [Good to know](#good-to-know)
+
+Besides the [pre made options](/docs/{{version}}/block-options), you can write your own option classes. A custom option is a class that extends `Jeffreyvr\Paver\Blocks\Options\Option` and returns a string of HTML from its `render` method.
+
+## Basic example
+
+```php
+use Jeffreyvr\Paver\Blocks\Options\Option;
+
+class ColorPicker extends Option
+{
+    public function __construct(
+        public string $label,
+        public string $name
+    ) {}
+
+    public function render(): string
+    {
+        return <<<HTML
+            <div class="paver__option">
+                <label>{$this->label}</label>
+                <input type="color" x-model="{$this->name}">
+            </div>
+        HTML;
+    }
+}
+```
+
+Use it in a block like any other option:
+
+```php
+function options()
+{
+    return [
+        ColorPicker::make('Background', 'background'),
+    ];
+}
+```
+
+## How binding works
+
+The options sidebar is Alpine powered. Paver exposes the block's data as a reactive scope, so binding an option value is a matter of using `x-model="your_option_name"`.
+
+Two things to keep in mind:
+
+- The option name must exist as a key in the block's `$data` array. Without it, there is no reactive property to bind to and changes will not be picked up.
+- Inside JavaScript that you embed in the option (for example an `x-data` component initializing a library), you can read and write the value by its bare name (`content = newValue`), because Alpine evaluates the expression within the block's data scope.
+
+## Loading scripts and styles
+
+If your option depends on a third party library, declare the assets in the option itself using `script` and `style`. Paver automatically outputs them on the page that renders the editor, deduplicated by handle and ordered so that dependencies load first.
+
+```php
+public function __construct(public string $label, public string $name)
+{
+    $this->script('jquery', 'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js');
+    $this->script('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.js', ['jquery']);
+    $this->style('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.css');
+}
+```
+
+The third argument of `script` is an array of handles this script depends on. If multiple blocks use the same option, each asset is only loaded once.
+
+## Full example: a Summernote rich text option
+
+```php
+use Jeffreyvr\Paver\Blocks\Options\Option;
+
+class RichText extends Option
+{
+    public function __construct(
+        public string $label,
+        public string $name,
+        public array $config = []
+    ) {
+        $this->script('jquery', 'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js');
+        $this->script('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.js', ['jquery']);
+        $this->style('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.css');
+    }
+
+    public function render(): string
+    {
+        $config = array_merge([
+            'height' => 300,
+            'dialogsInBody' => true,
+        ], $this->config);
+
+        $configJson = htmlentities(json_encode($config), ENT_QUOTES, 'UTF-8');
+
+        return <<<HTML
+            <div x-data="{
+                init() {
+                    jQuery(this.\$refs.editor).summernote({
+                        ...JSON.parse(JSON.stringify({$configJson})),
+                        callbacks: {
+                            onChange: (contents) => { {$this->name} = contents; },
+                            onInit: () => {
+                                jQuery(this.\$refs.editor).summernote('code', {$this->name} || '');
+                            }
+                        }
+                    });
+                }
+            }">
+                <div class="paver__option">
+                    <label>{$this->label}</label>
+                    <textarea x-ref="editor"></textarea>
+                </div>
+            </div>
+        HTML;
+    }
+}
+```
+
+And a block using it:
+
+```php
+use Jeffreyvr\Paver\Blocks\Block;
+
+class RichTextBlock extends Block
+{
+    public string $name = 'Rich text';
+
+    public static string $reference = 'your_prefix.richtext';
+
+    public array $data = [
+        'content' => '',
+    ];
+
+    public function options()
+    {
+        return [
+            RichText::make('Content', 'content', ['height' => 400]),
+        ];
+    }
+
+    public function render()
+    {
+        $content = $this->data['content'] ?? '';
+
+        if (trim($content) === '' && $this->isInEditor()) {
+            $content = '<p style="color: #9ca3af; padding: 15px;">Empty rich text block — click to edit…</p>';
+        }
+
+        return '<div>'.$content.'</div>';
+    }
+}
+```
+
+## Good to know
+
+- **Render a placeholder for empty blocks.** A block that renders empty HTML has no height in the editor, which makes it impossible to hover or click. Use `$this->isInEditor()` to render a placeholder in that case, like the example above.
+- **Dialogs and overlays.** The options sidebar creates a stacking context. Libraries that render modals inside your option (like Summernote's image dialog) may end up behind their own backdrop. Most libraries have an option to append dialogs to `<body>` instead — for Summernote that is `dialogsInBody: true`.
+- **Conditions work on custom options too.** Since your class extends `Option`, you get `->condition('some_value === true')` for free to conditionally show the option.

--- a/docs/beta/documentation.md
+++ b/docs/beta/documentation.md
@@ -6,6 +6,7 @@
 ### Essentials
 - [Making blocks](/docs/{{version}}/making-blocks)
 - [Block options](/docs/{{version}}/block-options)
+- [Custom options](/docs/{{version}}/custom-options)
 - [View templates](/docs/{{version}}/view-templates)
 - [Rendering](/docs/{{version}}/rendering)
 - [Storing](/docs/{{version}}/storing)

--- a/resources/views/editor.php
+++ b/resources/views/editor.php
@@ -36,6 +36,13 @@
 <?php echo paver()->loadAssetContent('/css/paver.css'); ?>
 </style>
 
+<?php foreach (paver()->optionAssets('styles') as $style) { ?>
+<link rel="stylesheet" href="<?php echo htmlspecialchars($style['src'], ENT_QUOTES, 'UTF-8'); ?>">
+<?php } ?>
+<?php foreach (paver()->optionAssets('scripts') as $script) { ?>
+<script src="<?php echo htmlspecialchars($script['src'], ENT_QUOTES, 'UTF-8'); ?>"></script>
+<?php } ?>
+
 <script>
     document.addEventListener('alpine:init', () => {
         Alpine.data('Paver', (data) => (

--- a/src/Blocks/Options/Option.php
+++ b/src/Blocks/Options/Option.php
@@ -6,11 +6,29 @@ abstract class Option
 {
     public array $attributes = [];
 
+    public array $scripts = [];
+
+    public array $styles = [];
+
     public string $wrapper = '_INJECT_';
 
     public static function make(...$args)
     {
         return new static(...$args);
+    }
+
+    public function script($handle, $src, $deps = [])
+    {
+        $this->scripts[] = compact('handle', 'src', 'deps');
+
+        return $this;
+    }
+
+    public function style($handle, $src, $deps = [])
+    {
+        $this->styles[] = compact('handle', 'src', 'deps');
+
+        return $this;
     }
 
     public function condition($condition)

--- a/src/Paver.php
+++ b/src/Paver.php
@@ -160,6 +160,57 @@ class Paver
         return $this;
     }
 
+    public function optionAssets(string $type): array
+    {
+        $assets = [];
+
+        foreach ($this->blocks as $block) {
+            $options = BlockFactory::createById($block['reference'])->options();
+
+            if (! is_array($options)) {
+                continue;
+            }
+
+            foreach ($options as $option) {
+                if (! $option instanceof Blocks\Options\Option) {
+                    continue;
+                }
+
+                foreach ($option->{$type} as $asset) {
+                    $assets[$asset['handle']] ??= $asset;
+                }
+            }
+        }
+
+        return $this->sortAssetsByDeps($assets);
+    }
+
+    protected function sortAssetsByDeps(array $assets): array
+    {
+        $visited = [];
+        $sorted = [];
+
+        $visit = function ($handle) use (&$visit, &$visited, &$sorted, $assets) {
+            if (isset($visited[$handle]) || ! isset($assets[$handle])) {
+                return;
+            }
+
+            $visited[$handle] = true;
+
+            foreach ($assets[$handle]['deps'] as $dep) {
+                $visit($dep);
+            }
+
+            $sorted[] = $assets[$handle];
+        };
+
+        foreach (array_keys($assets) as $handle) {
+            $visit($handle);
+        }
+
+        return $sorted;
+    }
+
     public function render(array|string|null $content = null, array $config = [])
     {
         if ($content === null) {

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -86,6 +86,108 @@ describe('Select Option', function () {
     });
 });
 
+describe('Option Assets', function () {
+    it('registers scripts and styles on an option', function () {
+        $input = Input::make('Test', 'test')
+            ->script('summernote', 'https://example.com/summernote.js', ['jquery'])
+            ->style('summernote', 'https://example.com/summernote.css');
+
+        expect($input->scripts)->toHaveCount(1);
+        expect($input->scripts[0]['handle'])->toBe('summernote');
+        expect($input->scripts[0]['deps'])->toBe(['jquery']);
+        expect($input->styles)->toHaveCount(1);
+    });
+
+    it('collects option assets from registered blocks', function () {
+        $block = new class extends \Jeffreyvr\Paver\Blocks\Block
+        {
+            public static string $reference = 'test.assets';
+
+            public function options()
+            {
+                return [
+                    Input::make('Content', 'content')
+                        ->script('jquery', 'https://example.com/jquery.js')
+                        ->script('summernote', 'https://example.com/summernote.js', ['jquery'])
+                        ->style('summernote', 'https://example.com/summernote.css'),
+                ];
+            }
+        };
+
+        paver()->blocks = [];
+        paver()->registerBlock(get_class($block));
+
+        $scripts = paver()->optionAssets('scripts');
+        $styles = paver()->optionAssets('styles');
+
+        expect(array_column($scripts, 'handle'))->toBe(['jquery', 'summernote']);
+        expect(array_column($styles, 'handle'))->toBe(['summernote']);
+    });
+
+    it('dedupes assets by handle and orders dependencies first', function () {
+        $blockA = new class extends \Jeffreyvr\Paver\Blocks\Block
+        {
+            public static string $reference = 'test.assets-a';
+
+            public function options()
+            {
+                return [
+                    Input::make('A', 'a')
+                        ->script('summernote', 'https://example.com/summernote.js', ['jquery'])
+                        ->script('jquery', 'https://example.com/jquery.js'),
+                ];
+            }
+        };
+
+        $blockB = new class extends \Jeffreyvr\Paver\Blocks\Block
+        {
+            public static string $reference = 'test.assets-b';
+
+            public function options()
+            {
+                return [
+                    Input::make('B', 'b')
+                        ->script('summernote', 'https://example.com/other-summernote.js'),
+                ];
+            }
+        };
+
+        paver()->blocks = [];
+        paver()->registerBlock(get_class($blockA));
+        paver()->registerBlock(get_class($blockB));
+
+        $scripts = paver()->optionAssets('scripts');
+
+        expect($scripts)->toHaveCount(2);
+        expect(array_column($scripts, 'handle'))->toBe(['jquery', 'summernote']);
+        expect($scripts[1]['src'])->toBe('https://example.com/summernote.js');
+    });
+
+    it('outputs option assets in the editor render', function () {
+        $block = new class extends \Jeffreyvr\Paver\Blocks\Block
+        {
+            public static string $reference = 'test.assets-render';
+
+            public function options()
+            {
+                return [
+                    Input::make('Content', 'content')
+                        ->script('summernote', 'https://example.com/summernote.js')
+                        ->style('summernote', 'https://example.com/summernote.css'),
+                ];
+            }
+        };
+
+        paver()->blocks = [];
+        paver()->registerBlock(get_class($block));
+
+        $html = (string) paver()->render();
+
+        expect($html)->toContain('<script src="https://example.com/summernote.js"></script>');
+        expect($html)->toContain('<link rel="stylesheet" href="https://example.com/summernote.css">');
+    });
+});
+
 describe('Option Wrapper', function () {
     it('has default wrapper', function () {
         $input = new Input('Test', 'test');

--- a/tests/localhost/assets.php
+++ b/tests/localhost/assets.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * Test page for option asset auto-loading.
+ *
+ * Both blocks below use the same RichText option, which declares jQuery and
+ * Summernote via $this->script() / $this->style(). Paver should output those
+ * tags once each, with jQuery before Summernote.
+ *
+ * Run: npm run start-server, then open http://localhost:8000/assets.php
+ */
+
+use Jeffreyvr\Paver\Blocks\Block;
+use Jeffreyvr\Paver\Blocks\Options\Option;
+use Jeffreyvr\Paver\Paver;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+class RichText extends Option
+{
+    public function __construct(
+        public string $label,
+        public string $name,
+        public array $config = []
+    ) {
+        $this->script('jquery', 'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js');
+        $this->script('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.js', ['jquery']);
+        $this->style('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.css');
+    }
+
+    public function render(): string
+    {
+        $config = array_merge([
+            'height' => 200,
+            'dialogsInBody' => true,
+        ], $this->config);
+
+        $configJson = htmlentities(json_encode($config), ENT_QUOTES, 'UTF-8');
+
+        return <<<HTML
+            <div x-data="{
+                init() {
+                    jQuery(this.\$refs.editor).summernote({
+                        ...JSON.parse(JSON.stringify({$configJson})),
+                        callbacks: {
+                            onChange: (contents) => { {$this->name} = contents; },
+                            onInit: () => {
+                                jQuery(this.\$refs.editor).summernote('code', {$this->name} || '');
+                            }
+                        }
+                    });
+                }
+            }">
+                <div class="paver__option">
+                    <label>{$this->label}</label>
+                    <textarea x-ref="editor"></textarea>
+                </div>
+            </div>
+        HTML;
+    }
+}
+
+abstract class RichTextBlock extends Block
+{
+    public array $data = [
+        'content' => '',
+    ];
+
+    public function options()
+    {
+        return [
+            RichText::make('Content', 'content'),
+        ];
+    }
+
+    public function render()
+    {
+        $content = $this->data['content'] ?? '';
+
+        if (trim($content) === '' && $this->isInEditor()) {
+            $content = '<p style="color: #9ca3af; padding: 15px;">Empty — click, then hit the pencil to edit…</p>';
+        }
+
+        return '<div>'.$content.'</div>';
+    }
+}
+
+class Intro extends RichTextBlock
+{
+    public string $name = 'Intro';
+
+    public static string $reference = 'assets_demo.intro';
+}
+
+class Outro extends RichTextBlock
+{
+    public string $name = 'Outro';
+
+    public static string $reference = 'assets_demo.outro';
+}
+
+$paver = Paver::instance();
+
+$paver->api->setEndpoints([
+    'options' => 'assets.php?options',
+    'render' => 'assets.php?render',
+    'fetch' => 'assets.php?fetch',
+]);
+
+// Both blocks share the same option, so its assets should be deduped.
+$paver->registerBlock(Intro::class);
+$paver->registerBlock(Outro::class);
+
+$content = [
+    ['block' => 'assets_demo.intro', 'data' => ['content' => '<p>Edit me to check the option works.</p>']],
+];
+
+// Endpoints exit the request, so blocks must be registered above this line.
+require 'endpoints.php';
+?>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<body class="flex h-screen">
+
+<?php echo $paver->render($content); ?>
+
+<div id="asset-check" style="position:fixed;bottom:12px;left:12px;z-index:9999;background:#111;color:#eee;font:12px/1.6 ui-monospace,monospace;padding:12px 16px;border-radius:8px;max-width:360px">
+    checking…
+</div>
+
+<script>
+    window.addEventListener('load', () => {
+        const srcs = Array.from(document.querySelectorAll('script[src]')).map(s => s.src);
+        const links = Array.from(document.querySelectorAll('link[rel=stylesheet]')).map(l => l.href);
+
+        const jqIndex = srcs.findIndex(s => s.includes('jquery'));
+        const snIndex = srcs.findIndex(s => s.includes('summernote'));
+
+        const checks = [
+            ['jQuery tag present', jqIndex !== -1],
+            ['Summernote tag present', snIndex !== -1],
+            ['Summernote CSS present', links.some(l => l.includes('summernote'))],
+            ['jQuery before Summernote', jqIndex !== -1 && snIndex !== -1 && jqIndex < snIndex],
+            ['Summernote JS loaded once (deduped)', srcs.filter(s => s.includes('summernote')).length === 1],
+            ['jQuery executed', typeof window.jQuery === 'function'],
+            ['Summernote plugin registered', !!(window.jQuery && window.jQuery.fn && window.jQuery.fn.summernote)],
+        ];
+
+        document.getElementById('asset-check').innerHTML =
+            '<strong>Option asset auto-loading</strong><br>' +
+            checks.map(([label, ok]) => (ok ? '✅ ' : '❌ ') + label).join('<br>') +
+            '<br><br>Open a block and hit the pencil — the sidebar should show a rich text editor.';
+    });
+</script>
+</body>


### PR DESCRIPTION
## What

Options can now declare the assets they need, and Paver loads them automatically on the editor page:

```php
class RichText extends Option
{
    public function __construct(public string $label, public string $name)
    {
        $this->script('jquery', 'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js');
        $this->script('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.js', ['jquery']);
        $this->style('summernote', 'https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.css');
    }
}
```

- `Option::script()` / `Option::style()` mirror the existing `Block` API (handle, src, deps).
- `Paver::optionAssets()` collects assets from all registered blocks' options, dedupes by handle (first registration wins), and orders dependencies before dependents.
- The editor view emits the `<link>`/`<script>` tags before Paver's own bundle, on the parent page — where the options sidebar actually lives.

## Why

Integrating a third-party library into a custom option (e.g. a Summernote rich text option) currently requires manually adding tags to the page that hosts the editor, and knowing that `frame->headHtml` targets the preview iframe rather than the sidebar. With this change a custom option is self-contained: registering a block whose options need a library is enough.

## Tests

Four new Pest tests cover declaration, collection across blocks, dedupe + dependency ordering, and tag output in `render()`. Full suite passes (77 tests, 141 assertions). Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)