### PR TITLE
Point composer prepare at the Vite build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "prepare": [
       "@x-ray",
       "@format",
-      "npx mix --production"
+      "npm run build"
     ]
   },
   "config": {


### PR DESCRIPTION
One-line follow-up to #25. The `prepare` composer script still called `npx mix --production`, which no longer exists after laravel-mix was removed, so `composer prepare` errored. It now runs `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)